### PR TITLE
Don't set use_all_identities_in_manage_relationship in test env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,9 +7,6 @@
 # General application configuration
 import Config
 
-# See https://ash-hq.org/docs/guides/ash/latest/tutorials/get-started#temporary-config
-config :ash, :use_all_identities_in_manage_relationship?, false
-
 config :peak_tracker, ecto_repos: [PeakTracker.Repo]
 config :peak_tracker, :ash_apis, [PeakTracker.Mountains]
 
@@ -30,6 +27,11 @@ config :logger, :console,
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
+
+if Mix.env() != :test do
+  # See https://ash-hq.org/docs/guides/ash/latest/tutorials/get-started#temporary-config
+  config :ash, :use_all_identities_in_manage_relationship?, false
+end
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
Somehow, Elixir was not happy about it being set. I don't understand enough about Elixir internals yet.

The error I got was:

```
ERROR! the application :ash has a different value set for key :use_all_identities_in_manage_relationship? during runtime compared to compile time. Since this application environment entry was marked as compile time, this difference can lead to differ
ent behaviour than expected:

  * Compile time value was not set
  * Runtime value was set to: false

To fix this error, you might:

  * Make the runtime value match the compile time one

  * Recompile your project. If the misconfigured application is a dependency, you may need to run "mix deps.compile ash --force"

  * Alternatively, you can disable this check. If you are using releases, you can set :validate_compile_env to false in your release configuration. If you are using Mix to start your system, you can pass the --no-validate-compile-env flag
```