### PR TITLE
Shorten log in flow

### DIFF
--- a/lib/peak_tracker_web/components/layouts/app.html.heex
+++ b/lib/peak_tracker_web/components/layouts/app.html.heex
@@ -21,7 +21,7 @@
         </a>
       <% else %>
         <a
-          href="/sign-in"
+          href="/auth/user/peak_tracker_auth"
           class="rounded-lg bg-zinc-100 px-2 py-1 text-[0.8125rem] font-semibold leading-6 text-zinc-900 hover:bg-zinc-200/80 active:text-zinc-900/70"
         >
           Sign In

--- a/lib/peak_tracker_web/router.ex
+++ b/lib/peak_tracker_web/router.ex
@@ -22,7 +22,6 @@ defmodule PeakTrackerWeb.Router do
 
     get "/", PageController, :root
 
-    sign_in_route()
     sign_out_route AuthController
     auth_routes_for PeakTracker.Accounts.User, to: AuthController
     reset_route []


### PR DESCRIPTION
This is possible because the actual log in happens in the external auth service.